### PR TITLE
adds a convenience module implementing `LocalDate::today()`

### DIFF
--- a/src/cal/convenience.rs
+++ b/src/cal/convenience.rs
@@ -1,0 +1,23 @@
+//! Adds convenience functions to some structs.
+//!
+//! # Example
+//! ```
+//! # use datetime::LocalDate;
+//! # use datetime::DatePiece;
+//! use datetime::convenience::Today;
+//! let today:LocalDate = LocalDate::today();
+//! ```
+use cal::datetime::{LocalDate,LocalDateTime};
+
+/// Adds `LocalDate::today() -> LocalDate`
+pub trait Today{
+    fn today() -> LocalDate;
+}
+
+impl Today for LocalDate{
+    fn today() -> LocalDate{
+        LocalDateTime::now().date()
+    }
+
+}
+

--- a/src/cal/mod.rs
+++ b/src/cal/mod.rs
@@ -7,6 +7,7 @@ pub mod iter;
 pub mod offset;
 pub mod parse;
 pub mod zone;
+pub mod convenience;
 
 pub use self::datetime::{LocalDate, LocalTime, LocalDateTime, Weekday, Month};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub use cal::offset::{Offset, OffsetDateTime};
 pub use cal::zone::{TimeZone, ZonedDateTime};
 pub use cal::zone as zone;
 
+pub use cal::convenience;
+
 mod duration;
 pub use duration::Duration;
 


### PR DESCRIPTION
Hey, what do you think of this?
The user would not be bothered with this, unless `datetime::convenience` is `use`d.