### PR TITLE
Use clock_gettime() as exposes by crate libc

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -13,10 +13,7 @@ extern {
 }
 
 #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios")))]
-extern {
-    fn clock_gettime(clk_id: libc::c_int, tp: *mut libc::timespec) -> libc::c_int;
-}
-
+use libc::clock_gettime;
 
 /// Returns the system’s current time, as a tuple of seconds elapsed since
 /// the Unix epoch, and the millisecond of the second.


### PR DESCRIPTION
It's better to use it from there. This fixes building on DragonFly.