### PR TITLE
Fix LocalDateTime::at for 29th February

### DIFF
--- a/src/cal/datetime.rs
+++ b/src/cal/datetime.rs
@@ -572,7 +572,7 @@ impl LocalDate {
         let num_4y_cycles = remainder / DAYS_IN_4Y;
         remainder -= num_4y_cycles * DAYS_IN_4Y;  // remainder is now days left in this 4-year cycle
 
-        let mut years = remainder / 365;
+        let mut years = std::cmp::min(remainder / 365, 3);
         remainder -= years * 365;  // remainder is now days left in this year
 
         // Leap year calculation goes thusly:

--- a/tests/instant_to_datetime.rs
+++ b/tests/instant_to_datetime.rs
@@ -92,3 +92,27 @@ fn just_some_date() {
     assert_eq!(date.minute(), 00);
     assert_eq!(date.second(), 00);
 }
+
+#[test]
+fn leap_year_some_date() {
+    let date = LocalDateTime::at(1459468800);
+
+    assert_eq!(date.year(),   2016);
+    assert_eq!(date.month(),  Month::April);
+    assert_eq!(date.day(),    1);
+    assert_eq!(date.hour(),   00);
+    assert_eq!(date.minute(), 00);
+    assert_eq!(date.second(), 00);
+}
+
+#[test]
+fn leap_year_29th_feb() {
+    let date = LocalDateTime::at(1456704000);
+
+    assert_eq!(date.year(),   2016);
+    assert_eq!(date.month(),  Month::February);
+    assert_eq!(date.day(),    29);
+    assert_eq!(date.hour(),   00);
+    assert_eq!(date.minute(), 00);
+    assert_eq!(date.second(), 00);
+}


### PR DESCRIPTION
The fix is to not allow years to be more than 3 after we subtracted 4y cycles.

Hello!
This should fix issue https://github.com/ogham/exa/issues/101

Should I bump the version in Cargo.toml?