### PR TITLE
Use newer winapi version 0.3.8 (and drop old kernel32)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ iso8601 = "0.3.0"
 
 
 [target.'cfg(windows)'.dependencies]
-kernel32-sys = "0.2.2"
-winapi = "0.2.8"
+winapi = { version = "0.3.8", features = ["sysinfoapi", "minwindef"] }
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.1.29"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ extern crate num_traits;
 extern crate pad;
 extern crate iso8601;
 
-#[cfg(windows)] extern crate kernel32;
 #[cfg(windows)] extern crate winapi;
 
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -31,7 +31,7 @@ pub unsafe fn sys_time() -> (i64, i16) {
     (tv.tv_sec, (tv.tv_usec / 1000) as i16)
 }
 
-#[cfg(windows)] use winapi::minwindef::FILETIME;
+#[cfg(windows)] use winapi::shared::minwindef::FILETIME;
 #[cfg(windows)] const HECTONANOSECS_IN_SEC: i64 = 10_000_000;
 #[cfg(windows)] const HECTONANOSEC_TO_UNIX_EPOCH: i64 = 11_644_473_600 * HECTONANOSECS_IN_SEC;
 
@@ -40,7 +40,7 @@ pub unsafe fn sys_time() -> (i64, i16) {
 #[cfg(any(target_os = "windows"))]
 pub unsafe fn sys_time() -> (i64, i16) {
     use std::mem;
-    use kernel32::GetSystemTimeAsFileTime;
+    use winapi::um::sysinfoapi::GetSystemTimeAsFileTime;
     let mut ft = mem::zeroed();
 
     GetSystemTimeAsFileTime(&mut ft);


### PR DESCRIPTION
This PR makes datetime use the newer version of winapi. With the new version there is no longer a need to use the old kernel32 crate as the functionality of that is in the newer winapi (as of 0.3).

The purpose is that downstream packages use datetime and using the current version 0.4.7 pulls in the old version of winapi which seems to fail on aarch64-pc-windows-msvc (ARM64). My hope is a new build of datetime (0.4.8) can be build and several downstream packages can use that so that they can be build on ARM64. Thanks.